### PR TITLE
New '--make-summary-multiline' option

### DIFF
--- a/docformatter.py
+++ b/docformatter.py
@@ -68,6 +68,7 @@ def _format_code(source,
                  summary_wrap_length=79,
                  description_wrap_length=72,
                  pre_summary_newline=False,
+                 make_summary_multiline=False,
                  post_description_blank=True,
                  force_wrap=False,
                  line_range=None):
@@ -116,6 +117,7 @@ def _format_code(source,
                 summary_wrap_length=summary_wrap_length,
                 description_wrap_length=description_wrap_length,
                 pre_summary_newline=pre_summary_newline,
+                make_summary_multiline=make_summary_multiline,
                 post_description_blank=post_description_blank,
                 force_wrap=force_wrap)
 
@@ -135,6 +137,7 @@ def format_docstring(indentation, docstring,
                      summary_wrap_length=0,
                      description_wrap_length=0,
                      pre_summary_newline=False,
+                     make_summary_multiline=False,
                      post_description_blank=True,
                      force_wrap=False):
     """Return formatted version of docstring.
@@ -199,10 +202,25 @@ def format_docstring(indentation, docstring,
             post_description=('\n' if post_description_blank else ''),
             indentation=indentation)
     else:
-        return wrap_summary('"""' + normalize_summary(contents) + '"""',
-                            wrap_length=summary_wrap_length,
-                            initial_indent=indentation,
-                            subsequent_indent=indentation).strip()
+        beginning = '"""'
+        ending = '"""'
+        if make_summary_multiline:
+            beginning = beginning + '\n' + indentation
+            ending = '\n' + indentation + ending
+            summary_wrapped = wrap_summary(normalize_summary(contents),
+                                           wrap_length=summary_wrap_length,
+                                           initial_indent=indentation,
+                                           subsequent_indent=indentation).strip()
+            return '{beginning}{summary}{ending}'.format(
+                beginning=beginning,
+                summary=summary_wrapped,
+                ending=ending
+            )
+        else:
+            return wrap_summary('"""' + normalize_summary(contents) + '"""',
+                                wrap_length=summary_wrap_length,
+                                initial_indent=indentation,
+                                subsequent_indent=indentation).strip()
 
 
 def reindent(text, indentation):
@@ -494,6 +512,7 @@ def _format_code_with_args(source, args):
         summary_wrap_length=args.wrap_summaries,
         description_wrap_length=args.wrap_descriptions,
         pre_summary_newline=args.pre_summary_newline,
+        make_summary_multiline=args.make_summary_multiline,
         post_description_blank=args.post_description_blank,
         force_wrap=args.force_wrap,
         line_range=args.line_range)
@@ -522,6 +541,10 @@ def _main(argv, standard_out, standard_error, standard_in):
                         action='store_true',
                         help='add a newline before the summary of a '
                              'multi-line docstring')
+    parser.add_argument('--make-summary-multiline',
+                        action='store_true',
+                        help='add a newline before and after the summary of a '
+                             'one-line docstring')
     parser.add_argument('--force-wrap', action='store_true',
                         help='force descriptions to be wrapped even if it may '
                              'result in a mess')

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -1098,6 +1098,16 @@ num_iterations is the number of updates - instead of a better definition of conv
         self.assertFalse(docformatter.is_probably_beginning_of_sentence(
             '(this just continues an existing sentence).'))
 
+    def test_format_docstring_make_summary_multiline(self):
+        self.assertEqual(('''\
+"""
+    This oneline docstring will be multiline.
+    """\
+'''),
+                         docformatter.format_docstring('    ', '''\
+"""This oneline docstring will be multiline"""\
+''', make_summary_multiline=True))
+
 
 class TestSystem(unittest.TestCase):
 


### PR DESCRIPTION
This is not recommended by the PEP 257, but there are some project that
use it in this way. So, a new '--make-summary-multiline' option is added
to allow those project to be able to use the rest of the docformatter
features.

When this option is set as True and use docformatter over a function
like this one:

```python
def function():
    """This is a one line summary that will be converted to multiline."""
```

the result will be:

```python
def function():
    """
    This is a one line summary that will be converted to multiline.
    """
```