### PR TITLE
Support colon-separated argument lists

### DIFF
--- a/docformatter.py
+++ b/docformatter.py
@@ -339,7 +339,9 @@ def is_some_sort_of_list(text):
             # "@parameter"
             re.match(r'\s*[\-*:=@]', line) or
             # "parameter - description"
-            re.match(r'.*\s+[\-*:=@]\s+', line)
+            re.match(r'.*\s+[\-*:=@]\s+', line) or
+            # "parameter: description"
+            re.match(r'\s*\S+[\-*:=@]\s+', line)
         ):
             return True
 

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -227,6 +227,19 @@ Hello.
                                           docstring,
                                           description_wrap_length=72))
 
+    def test_format_docstring_should_ignore__colon_parameter_lists(self):
+        docstring = '''"""Hello.
+
+    foo: This is a foo. This is a foo. This is a foo. This is a foo. This is.
+    bar: This is a bar. This is a bar. This is a bar. This is a bar. This is.
+
+    """'''
+        self.assertEqual(
+            docstring,
+            docformatter.format_docstring('    ',
+                                          docstring,
+                                          description_wrap_length=72))
+
     def test_format_docstring_should_ignore_multi_paragraph(self):
         docstring = '''"""Hello.
 


### PR DESCRIPTION
Adds support for argument lists like:
```Args:
  x: the first argument
  y: the second argument
```

Currently the system works for these already, kind of.  If the docstring looks like:

```python
def f(x, y):
    """The identity function.

    Returns what you give it.

    Args:
      x: the argument
      y: ignored
    """
    return x
```
then docformatter does the right thing and leaves it alone.  But if the comment looks like:

```python
def f(x, y):
    """The identity function.

    Args:
      x: the argument
      y: ignored
    """
    return x
```
(note the missing second paragraph) then docformatter suggests

```python
def f(x):
    """The identity function.

    Args:   x: the argument   y: ignored
    """
    return x
```

Which it seems like is a bug. This updates the code to work properly in this case and adds a corresponding test case.