### PR TITLE
Lean toward the second line being the description

### DIFF
--- a/docformatter.py
+++ b/docformatter.py
@@ -241,6 +241,10 @@ def is_probably_beginning_of_sentence(line):
         if re.search(r'\s' + token + r'\s', line):
             return True
 
+        stripped_line = line.strip()
+        if stripped_line and stripped_line[0].isupper():
+            return True
+
     return re.match(r'[^\w"\'`\(\)]', line.strip())
 
 

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -855,10 +855,11 @@ def foo():
                          docformatter.split_summary_and_description(
                              'This is the first\none - one\ntwo - two'))
 
-    def test_split_summary_and_description_with_capital(self):
-        self.assertEqual(('This is the first\nWashington', ''),
+    def test_split_summary_and_description_with_no_punctuation_between(self):
+        self.assertEqual(('This is the first',
+                          'This is the second'),
                          docformatter.split_summary_and_description(
-                             'This is the first\nWashington'))
+                             'This is the first\nThis is the second'))
 
     def test_split_summary_and_description_with_list_on_other_line(self):
         self.assertEqual(('Test\n    test', '    @blah'),


### PR DESCRIPTION
This will handle the case where the second line is a description due to starting with a capital letter. But it will break cases where the capital is due to the word being a pronoun.

I'm not sure yet if I want to merge this. It will fix the case that @Hnasar described in https://github.com/myint/docformatter/issues/9#issuecomment-377563321, but it will break cases like:

```python
def foo():
    """We will go to
    Washington
    """
```

Maybe that case is rare. Perhaps we should get some metrics.