### PR TITLE
Add pre-commit hooks for docformatter

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: docformatter
+    name: docformatter
+    description: 'Formats docstrings to follow PEP 257.'
+    entry: docformatter
+    language: python
+    types: [python]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,10 @@
     entry: docformatter
     language: python
     types: [python]
+-   id: docformatter-venv
+    name: docformatter-venv
+    description: 'Formats docstrings to follow PEP 257. Uses python3 -m venv.'
+    entry: docformatter
+    language: python_venv
+    types: [python]
+


### PR DESCRIPTION
See pre-commit documentation at https://pre-commit.com.

This makes it convenient for people to automatically run docfomatter
when committing code to their codebase.

[Example usage](https://github.com/akbiggs/challonge-tools/blob/master/.pre-commit-config.yaml#L7).