### PR TITLE
Support Windows-style line endings

### DIFF
--- a/docformatter.py
+++ b/docformatter.py
@@ -73,10 +73,10 @@ def format_code(source, **kwargs):
     See "_format_code()" for parameters.
     """
     try:
-        original_newline = find_newline(source.splitlines(keepends=True))
+        original_newline = find_newline(source.splitlines(True))
         code = _format_code(source, **kwargs)
 
-        return normalize_line_endings(code.splitlines(keepends=True), original_newline)
+        return normalize_line_endings(code.splitlines(True), original_newline)
     except (tokenize.TokenError, IndentationError):
         return source
 

--- a/docformatter.py
+++ b/docformatter.py
@@ -57,6 +57,7 @@ CR = '\r'
 LF = '\n'
 CRLF = '\r\n'
 
+
 class FormatResult(object):  # pylint: disable=too-few-public-methods, useless-object-inheritance
     """Possible exit codes."""
     ok = 0

--- a/docformatter.py
+++ b/docformatter.py
@@ -388,6 +388,7 @@ def _find_shortest_indentation(lines):
 
 def find_newline(source):
     """Return type of newline used in source.
+
     Input is a list of lines.
     """
     assert not isinstance(source, unicode)
@@ -405,7 +406,8 @@ def find_newline(source):
 
 def normalize_line(line, newline):
     """Return line with fixed ending, if ending was present in line.
-       Otherwise, does nothing.
+
+    Otherwise, does nothing.
     """
     stripped = line.rstrip('\n\r')
     if stripped != line:
@@ -415,6 +417,7 @@ def normalize_line(line, newline):
 
 def normalize_line_endings(lines, newline):
     """Return fixed line endings.
+
     All lines will be modified to use the most common line ending.
     """
     return "".join([normalize_line(line, newline) for line in lines])

--- a/docformatter.py
+++ b/docformatter.py
@@ -53,6 +53,9 @@ except NameError:
 
 HEURISTIC_MIN_LIST_ASPECT_RATIO = .4
 
+CR = '\r'
+LF = '\n'
+CRLF = '\r\n'
 
 class FormatResult(object):  # pylint: disable=too-few-public-methods, useless-object-inheritance
     """Possible exit codes."""
@@ -70,7 +73,10 @@ def format_code(source, **kwargs):
     See "_format_code()" for parameters.
     """
     try:
-        return _format_code(source, **kwargs)
+        original_newline = find_newline(source.splitlines(keepends=True))
+        code = _format_code(source, **kwargs)
+
+        return normalize_line_endings(code.splitlines(keepends=True), original_newline)
     except (tokenize.TokenError, IndentationError):
         return source
 
@@ -380,6 +386,39 @@ def _find_shortest_indentation(lines):
 
     return indentation or ''
 
+def find_newline(source):
+    """Return type of newline used in source.
+    Input is a list of lines.
+    """
+    assert not isinstance(source, unicode)
+
+    counter = collections.defaultdict(int)
+    for line in source:
+        if line.endswith(CRLF):
+            counter[CRLF] += 1
+        elif line.endswith(CR):
+            counter[CR] += 1
+        elif line.endswith(LF):
+            counter[LF] += 1
+    return (sorted(counter, key=counter.get, reverse=True) or [LF])[0]
+
+
+def normalize_line(line, newline):
+    """Return line with fixed ending, if ending was present in line.
+       Otherwise, does nothing.
+    """
+    stripped = line.rstrip('\n\r')
+    if stripped != line:
+        return stripped + newline
+    return line
+
+
+def normalize_line_endings(lines, newline):
+    """Return fixed line endings.
+    All lines will be modified to use the most common line ending.
+    """
+    return "".join([normalize_line(line, newline) for line in lines])
+    
 
 def strip_docstring(docstring):
     """Return contents of docstring."""

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -822,6 +822,25 @@ def foo():
         self.assertEqual('"""\n',
                          docformatter.format_code('"""\n'))
 
+    def test_test_format_code_dominant_line_ending_style_preserved(self):
+        input = '''\
+def foo():\r
+    """\r
+    Hello\r
+    foo. This is a docstring.\r
+    """\r
+'''
+        self.assertEqual(docformatter.CRLF, docformatter.find_newline(input.splitlines(keepends=True)))
+        self.assertEqual(
+            '''\
+def foo():\r
+    """Hello foo.\r
+\r
+    This is a docstring.\r
+    """\r
+''',
+            docformatter.format_code(input))
+
     def test_split_summary_and_description(self):
         self.assertEqual(
             ('This is the first.',

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -822,7 +822,7 @@ def foo():
         self.assertEqual('"""\n',
                          docformatter.format_code('"""\n'))
 
-    def test_test_format_code_dominant_line_ending_style_preserved(self):
+    def test_format_code_dominant_line_ending_style_preserved(self):
         input = '''\
 def foo():\r
     """\r

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -822,6 +822,38 @@ def foo():
         self.assertEqual('"""\n',
                          docformatter.format_code('"""\n'))
 
+    def test_format_code_with_syntax_error_case_slash_r(self):
+        self.assertEqual('"""\r',
+                         docformatter.format_code('"""\r'))
+
+    def test_format_code_with_syntax_error_case_slash_r_slash_n(self):
+        self.assertEqual('"""\r\n',
+                         docformatter.format_code('"""\r\n'))
+
+    def test_find_newline_only_cr(self):
+        source = ['print 1\r', 'print 2\r', 'print3\r']
+        self.assertEqual(docformatter.CR, docformatter.find_newline(source))
+
+    def test_find_newline_only_lf(self):
+        source = ['print 1\n', 'print 2\n', 'print3\n']
+        self.assertEqual(docformatter.LF, docformatter.find_newline(source))
+
+    def test_find_newline_only_crlf(self):
+        source = ['print 1\r\n', 'print 2\r\n', 'print3\r\n']
+        self.assertEqual(docformatter.CRLF, docformatter.find_newline(source))
+
+    def test_find_newline_cr1_and_lf2(self):
+        source = ['print 1\n', 'print 2\r', 'print3\n']
+        self.assertEqual(docformatter.LF, docformatter.find_newline(source))
+
+    def test_find_newline_cr1_and_crlf2(self):
+        source = ['print 1\r\n', 'print 2\r', 'print3\r\n']
+        self.assertEqual(docformatter.CRLF, docformatter.find_newline(source))
+
+    def test_find_newline_should_default_to_lf(self):
+        self.assertEqual(docformatter.LF, docformatter.find_newline([]))
+        self.assertEqual(docformatter.LF, docformatter.find_newline(['', '']))
+
     def test_format_code_dominant_line_ending_style_preserved(self):
         input = '''\
 def foo():\r

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -830,7 +830,7 @@ def foo():\r
     foo. This is a docstring.\r
     """\r
 '''
-        self.assertEqual(docformatter.CRLF, docformatter.find_newline(input.splitlines(keepends=True)))
+        self.assertEqual(docformatter.CRLF, docformatter.find_newline(input.splitlines(True)))
         self.assertEqual(
             '''\
 def foo():\r


### PR DESCRIPTION
This closes #22.

Please review, and if accepted, create new release of docformatter( This issue is affecting me, as it prevents using docformatter in pre-commit hooks - leads to changes in file only due to line endings, and conflicts with reorder_python_imports)