### PR TITLE
A pydoc reference such as ':see:' should not be start of sentence

### DIFF
--- a/docformatter.py
+++ b/docformatter.py
@@ -258,7 +258,11 @@ def is_probably_beginning_of_sentence(line):
         if re.search(r'\s' + token + r'\s', line):
             return True
 
-    return re.match(r'[^\w"\'`\(\)]', line.strip())
+    stripped_line = line.strip()
+    is_beginning_of_sentence = re.match(r'[^\w"\'`\(\)]', stripped_line)
+    is_pydoc_ref = re.match(r'^:\w+:', stripped_line)
+
+    return is_beginning_of_sentence and not is_pydoc_ref
 
 
 def split_summary_and_description(contents):

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -1168,6 +1168,10 @@ num_iterations is the number of updates - instead of a better definition of conv
         self.assertFalse(docformatter.is_probably_beginning_of_sentence(
             '(this just continues an existing sentence).'))
 
+    def test_is_probably_beginning_of_sentence_pydoc_ref(self):
+        self.assertFalse(docformatter.is_probably_beginning_of_sentence(
+            ':see:MyClass This is not the start of a sentence.'))
+
     def test_format_docstring_make_summary_multi_line(self):
         self.assertEqual(('''\
 """


### PR DESCRIPTION
Fixes the issue described here: https://github.com/myint/docformatter/issues/16