### PR TITLE
Added command line exclude option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,8 @@ Below is the help output::
       -i, --in-place        make changes to files instead of printing diffs
       -c, --check           only check and report incorrectly formatted files
       -r, --recursive       drill down directories recursively
+      -e, --exclude         exclude directories and files by names
+
       --wrap-summaries length
                             wrap long summary lines at this length; set to 0 to
                             disable wrapping (default: 79)

--- a/docformatter.py
+++ b/docformatter.py
@@ -711,6 +711,8 @@ def find_py_files(sources, recursive, exclude=None):
 
     def is_excluded(name, exclude):
         """Return True if file 'name' is excluded."""
+        if not exclude:
+            return False
         return True if re.search(re.escape(exclude), name, re.IGNORECASE) else False
 
     for name in sorted(sources):

--- a/docformatter.py
+++ b/docformatter.py
@@ -610,8 +610,8 @@ def _main(argv, standard_out, standard_error, standard_in):
                               'files')
     parser.add_argument('-r', '--recursive', action='store_true',
                         help='drill down directories recursively')
-    parser.add_argument('-e', '--exclude', default=None, type=str,
-                        help='exclude directories and files by name')
+    parser.add_argument('-e', '--exclude',
+                        help='exclude directories and files by names')
     parser.add_argument('--wrap-summaries', default=79, type=int,
                         metavar='length',
                         help='wrap long summary lines at this length; '

--- a/docformatter.py
+++ b/docformatter.py
@@ -713,7 +713,10 @@ def find_py_files(sources, recursive, exclude=None):
         """Return True if file 'name' is excluded."""
         if not exclude:
             return False
-        return re.search(re.escape(exclude), name, re.IGNORECASE)
+        for e in exclude:
+            if re.search(re.escape(str(e)), name, re.IGNORECASE):
+                return True
+        return False
 
     for name in sorted(sources):
         if recursive and os.path.isdir(name):

--- a/docformatter.py
+++ b/docformatter.py
@@ -38,8 +38,7 @@ import signal
 import sys
 import textwrap
 import tokenize
-from distutils.sysconfig import get_python_lib
-
+import sysconfig
 import untokenize
 
 
@@ -58,6 +57,7 @@ CR = '\r'
 LF = '\n'
 CRLF = '\r\n'
 
+_PYTHON_LIBS = set(sysconfig.get_paths().values())
 
 class FormatResult(object):
     """Possible exit codes."""
@@ -718,10 +718,12 @@ def find_py_files(sources, recursive, exclude=None):
                 return True
         return False
 
+
+
     for name in sorted(sources):
         if recursive and os.path.isdir(name):
             for root, dirs, children in os.walk(unicode(name)):
-                dirs[:] = [d for d in dirs if not_hidden(d) and not is_excluded(d, [get_python_lib()])]
+                dirs[:] = [d for d in dirs if not_hidden(d) and not is_excluded(d, _PYTHON_LIBS)]
                 dirs[:] = sorted([d for d in dirs if not is_excluded(d, exclude)])
                 files = sorted([f for f in children if not_hidden(f) and not is_excluded(f, exclude)])
                 for filename in files:

--- a/docformatter.py
+++ b/docformatter.py
@@ -609,6 +609,8 @@ def _main(argv, standard_out, standard_error, standard_in):
                               'files')
     parser.add_argument('-r', '--recursive', action='store_true',
                         help='drill down directories recursively')
+    parser.add_argument('-e', '--exclude', default=None, type=str,
+                        help='exclude directories and files by name')
     parser.add_argument('--wrap-summaries', default=79, type=int,
                         metavar='length',
                         help='wrap long summary lines at this length; '
@@ -692,12 +694,13 @@ def _get_encoding():
     return locale.getpreferredencoding() or sys.getdefaultencoding()
 
 
-def find_py_files(sources, recursive):
+def find_py_files(sources, recursive, exclude=None):
     """Find Python source files.
 
     Parameters
         - sources: iterable with paths as strings.
         - recursive: drill down directories if True.
+        - exclude: string based on which directores and files are excluded.
 
     Return: yields paths to found files.
     """
@@ -705,11 +708,17 @@ def find_py_files(sources, recursive):
         """Return True if file 'name' isn't .hidden."""
         return not name.startswith('.')
 
+    def is_excluded(name, exclude):
+        """Return True if file 'name' is excluded."""
+        return True if re.search(re.escape(exclude), name, re.IGNORECASE) else False
+
     for name in sorted(sources):
         if recursive and os.path.isdir(name):
             for root, dirs, children in os.walk(unicode(name)):
-                dirs[:] = sorted(filter(not_hidden, dirs))
-                for filename in sorted(filter(not_hidden, children)):
+                dirs[:] = [d for d in dirs if not_hidden(d) and not is_excluded(d, get_python_lib())]
+                dirs[:] = sorted([d for d in dirs if not is_excluded(d, exclude)])
+                files = sorted([f for f in children if not_hidden(f) and not is_excluded(f, exclude)])
+                for filename in files:
                     if filename.endswith('.py'):
                         yield os.path.join(root, filename)
         else:
@@ -722,7 +731,7 @@ def _format_files(args, standard_out, standard_error):
     Return: one of the FormatResult codes.
     """
     outcomes = collections.Counter()
-    for filename in find_py_files(set(args.files), args.recursive):
+    for filename in find_py_files(set(args.files), args.recursive, args.exclude):
         try:
             result = format_file(filename, args=args,
                                  standard_out=standard_out)

--- a/docformatter.py
+++ b/docformatter.py
@@ -610,7 +610,7 @@ def _main(argv, standard_out, standard_error, standard_in):
                               'files')
     parser.add_argument('-r', '--recursive', action='store_true',
                         help='drill down directories recursively')
-    parser.add_argument('-e', '--exclude', action='store_true',
+    parser.add_argument('-e', '--exclude', nargs="*",
                         help='exclude directories and files by names')
     parser.add_argument('--wrap-summaries', default=79, type=int,
                         metavar='length',
@@ -721,7 +721,7 @@ def find_py_files(sources, recursive, exclude=None):
     for name in sorted(sources):
         if recursive and os.path.isdir(name):
             for root, dirs, children in os.walk(unicode(name)):
-                dirs[:] = [d for d in dirs if not_hidden(d) and not is_excluded(d, get_python_lib())]
+                dirs[:] = [d for d in dirs if not_hidden(d) and not is_excluded(d, [get_python_lib()])]
                 dirs[:] = sorted([d for d in dirs if not is_excluded(d, exclude)])
                 files = sorted([f for f in children if not_hidden(f) and not is_excluded(f, exclude)])
                 for filename in files:

--- a/docformatter.py
+++ b/docformatter.py
@@ -38,6 +38,7 @@ import signal
 import sys
 import textwrap
 import tokenize
+from distutils.sysconfig import get_python_lib
 
 import untokenize
 
@@ -700,7 +701,7 @@ def find_py_files(sources, recursive, exclude=None):
     Parameters
         - sources: iterable with paths as strings.
         - recursive: drill down directories if True.
-        - exclude: string based on which directores and files are excluded.
+        - exclude: string based on which directories and files are excluded.
 
     Return: yields paths to found files.
     """

--- a/docformatter.py
+++ b/docformatter.py
@@ -610,7 +610,7 @@ def _main(argv, standard_out, standard_error, standard_in):
                               'files')
     parser.add_argument('-r', '--recursive', action='store_true',
                         help='drill down directories recursively')
-    parser.add_argument('-e', '--exclude',
+    parser.add_argument('-e', '--exclude', action='store_true',
                         help='exclude directories and files by names')
     parser.add_argument('--wrap-summaries', default=79, type=int,
                         metavar='length',

--- a/docformatter.py
+++ b/docformatter.py
@@ -713,13 +713,13 @@ def find_py_files(sources, recursive, exclude=None):
         """Return True if file 'name' is excluded."""
         if not exclude:
             return False
-        return True if re.search(re.escape(exclude), name, re.IGNORECASE) else False
+        return re.search(re.escape(exclude), name, re.IGNORECASE)
 
     for name in sorted(sources):
         if recursive and os.path.isdir(name):
             for root, dirs, children in os.walk(unicode(name)):
                 dirs[:] = [d for d in dirs if not_hidden(d) and not is_excluded(d, get_python_lib())]
-                dirs[:] = sorted([d for d in dirs if not is_excluded(d, exclude)])
+                dirs[:] = sorted([d for d in dirs if is_excluded(d, exclude)])
                 files = sorted([f for f in children if not_hidden(f) and not is_excluded(f, exclude)])
                 for filename in files:
                     if filename.endswith('.py'):

--- a/docformatter.py
+++ b/docformatter.py
@@ -719,10 +719,10 @@ def find_py_files(sources, recursive, exclude=None):
         if recursive and os.path.isdir(name):
             for root, dirs, children in os.walk(unicode(name)):
                 dirs[:] = [d for d in dirs if not_hidden(d) and not is_excluded(d, get_python_lib())]
-                dirs[:] = sorted([d for d in dirs if is_excluded(d, exclude)])
+                dirs[:] = sorted([d for d in dirs if not is_excluded(d, exclude)])
                 files = sorted([f for f in children if not_hidden(f) and not is_excluded(f, exclude)])
                 for filename in files:
-                    if filename.endswith('.py'):
+                    if filename.endswith('.py') and not is_excluded(root, exclude):
                         yield os.path.join(root, filename)
         else:
             yield name

--- a/setup.py
+++ b/setup.py
@@ -38,4 +38,5 @@ with open('README.rst') as readme:
           entry_points={
               'console_scripts': ['docformatter = docformatter:main']},
           install_requires=['untokenize'],
+          tests_require=['mock;python_version<"3.3"'],
           test_suite='test_docformatter')

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -1183,6 +1183,27 @@ num_iterations is the number of updates - instead of a better definition of conv
 """This one-line docstring will be multi-line"""\
 ''', make_summary_multi_line=True))
 
+    def test_exclude_option(self):
+        import docformatter
+        sources = {"/root"}
+        roots = [
+            ("/root", ['folder_one', 'folder_two'], []),
+            ("/root/folder_one", ['folder_three'], ["one.py"]),
+            ("/root/folder_one/folder_three", [], ["three.py"]),
+            ("/root/folder_two", [], ["two.py"]),
+        ]
+        with patch("os.walk", return_value=roots), patch("os.path.isdir", return_value=True):
+            test_exclude_one = list(docformatter.find_py_files(sources, True, "folder_one"))
+            self.assertEqual(test_exclude_one, ['/root/folder_two/two.py'])
+            test_exclude_two = list(docformatter.find_py_files(sources, True, "folder_two"))
+            self.assertEqual(test_exclude_two, ['/root/folder_one/one.py', '/root/folder_one/folder_three/three.py'])
+            test_exclude_three = list(docformatter.find_py_files(sources, True, "folder_three"))
+            self.assertEqual(test_exclude_three, ['/root/folder_one/one.py', '/root/folder_two/two.py'])
+            test_exclude_py = list(docformatter.find_py_files(sources, True, ".py"))
+            self.assertFalse(test_exclude_py)
+
+
+
 
 class TestSystem(unittest.TestCase):
 
@@ -1418,15 +1439,6 @@ Print my path and return error code
                              msg='Do not write to stdout')
             self.assertEqual(stderr.getvalue().strip(), filename,
                              msg='Changed file should be reported')
-
-    def test_exclude_option(self):
-        sources = {"/root"}
-        roots = [("/root", ['folder_one', 'folder_two'], []),
-                 ("/root/folder_one", ['folder_three'], ["one.txt"]),
-                 ("/root/folder_one/folder_three", [], ["three.txt"]),
-                 ("/root/folder_two",), [], ["two.txt"]]
-        with patch.object(docformatter, "find_py_files", side_effect=roots):
-            docformatter.find_py_files(sources, True)
 
 
 def generate_random_docstring(max_indentation_length=32,

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -17,7 +17,11 @@ import subprocess
 import sys
 import tempfile
 import unittest
-from unittest.mock import patch
+
+if sys.version_info >= (3, 3):
+    from unittest.mock import patch
+else:
+    from mock import patch
 
 import docformatter
 

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -1183,27 +1183,41 @@ num_iterations is the number of updates - instead of a better definition of conv
 """This one-line docstring will be multi-line"""\
 ''', make_summary_multi_line=True))
 
-    def test_exclude_option(self):
-        import docformatter
+    def test_exclude(self):
         sources = {"/root"}
-        roots = [
+        patch_data = [
             ("/root", ['folder_one', 'folder_two'], []),
             ("/root/folder_one", ['folder_three'], ["one.py"]),
             ("/root/folder_one/folder_three", [], ["three.py"]),
             ("/root/folder_two", [], ["two.py"]),
         ]
-        with patch("os.walk", return_value=roots), patch("os.path.isdir", return_value=True):
-            test_exclude_one = list(docformatter.find_py_files(sources, True, "folder_one"))
+        with patch("os.walk", return_value=patch_data), patch("os.path.isdir", return_value=True):
+            test_exclude_one = list(docformatter.find_py_files(sources, True, ["folder_one"]))
             self.assertEqual(test_exclude_one, ['/root/folder_two/two.py'])
-            test_exclude_two = list(docformatter.find_py_files(sources, True, "folder_two"))
+            test_exclude_two = list(docformatter.find_py_files(sources, True, ["folder_two"]))
             self.assertEqual(test_exclude_two, ['/root/folder_one/one.py', '/root/folder_one/folder_three/three.py'])
-            test_exclude_three = list(docformatter.find_py_files(sources, True, "folder_three"))
+            test_exclude_three = list(docformatter.find_py_files(sources, True, ["folder_three"]))
             self.assertEqual(test_exclude_three, ['/root/folder_one/one.py', '/root/folder_two/two.py'])
             test_exclude_py = list(docformatter.find_py_files(sources, True, ".py"))
             self.assertFalse(test_exclude_py)
+            test_exclude_two_and_three = list(docformatter.find_py_files(sources, True, ["folder_two", "folder_three"]))
+            self.assertEqual(test_exclude_two_and_three, ['/root/folder_one/one.py'])
 
-
-
+    def test_exclude_nothing(self):
+        sources = {"/root"}
+        patch_data = [
+            ("/root", ['folder_one', 'folder_two'], []),
+            ("/root/folder_one", ['folder_three'], ["one.py"]),
+            ("/root/folder_one/folder_three", [], ["three.py"]),
+            ("/root/folder_two", [], ["two.py"]),
+        ]
+        with patch("os.walk", return_value=patch_data), patch("os.path.isdir", return_value=True):
+            test_exclude_nothing = list(docformatter.find_py_files(sources, True, []))
+            self.assertEqual(test_exclude_nothing, ['/root/folder_one/one.py', '/root/folder_one/folder_three/three.py',
+                                                    '/root/folder_two/two.py'])
+            test_exclude_nothing = list(docformatter.find_py_files(sources, True))
+            self.assertEqual(test_exclude_nothing, ['/root/folder_one/one.py', '/root/folder_one/folder_three/three.py',
+                                                    '/root/folder_two/two.py'])
 
 class TestSystem(unittest.TestCase):
 

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -1202,6 +1202,8 @@ num_iterations is the number of updates - instead of a better definition of conv
             self.assertFalse(test_exclude_py)
             test_exclude_two_and_three = list(docformatter.find_py_files(sources, True, ["folder_two", "folder_three"]))
             self.assertEqual(test_exclude_two_and_three, ['/root/folder_one/one.py'])
+            test_exclude_files = list(docformatter.find_py_files(sources, True, ["one.py", "two.py"]))
+            self.assertEqual(test_exclude_files, ['/root/folder_one/folder_three/three.py'])
 
     def test_exclude_nothing(self):
         sources = {"/root"}

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import docformatter
 
@@ -1417,6 +1418,15 @@ Print my path and return error code
                              msg='Do not write to stdout')
             self.assertEqual(stderr.getvalue().strip(), filename,
                              msg='Changed file should be reported')
+
+    def test_exclude_option(self):
+        sources = {"/root"}
+        roots = [("/root", ['folder_one', 'folder_two'], []),
+                 ("/root/folder_one", ['folder_three'], ["one.txt"]),
+                 ("/root/folder_one/folder_three", [], ["three.txt"]),
+                 ("/root/folder_two",), [], ["two.txt"]]
+        with patch.object(docformatter, "find_py_files", side_effect=roots):
+            docformatter.find_py_files(sources, True)
 
 
 def generate_random_docstring(max_indentation_length=32,


### PR DESCRIPTION
Added a simple exclude command line option which can be used to exclude folders and files. Further site-packages get excluded.

Exclusion can be triggered via the `-e` or `--exclude` flag following multiple folder or file names e.g. `-e <folder> <folder> <file>`. Files and folders are excluded in the `find_py_files` method via `re.search`.